### PR TITLE
fix  `strict` mode on versions of Node.js older than iojs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.sublime-*
 node_modules
 npm-debug.log
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "node"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # window-size [![NPM version](https://badge.fury.io/js/window-size.svg)](http://badge.fury.io/js/window-size)
 
+[![Build Status](https://travis-ci.org/jonschlinkert/window-size.svg)](https://travis-ci.org/jonschlinkert/window-size)
+
 > Reliable way to to get the height and width of the terminal/console in a node.js environment.
 
 ## Install

--- a/cli.js
+++ b/cli.js
@@ -9,7 +9,7 @@ var helpText = ['Usage',
 '  width : 145',
 ''].join('\n');
 
-function showSize() {
+function showSize () {
   var size = require('./');
   console.log('height: ' + size.height);
   console.log('width : ' + size.width);
@@ -21,7 +21,7 @@ if (process.argv.length > 2) {
     case '--help':
     case '-h':
       console.log(helpText);
-    break;
+      break;
     default:
       showSize();
   }

--- a/index.js
+++ b/index.js
@@ -9,12 +9,12 @@
 
 var tty = require('tty');
 
-module.exports = (function() {
+module.exports = (function () {
   var width;
   var height;
 
-  if(tty.isatty(1) && tty.isatty(2)) {
-    if(process.stdout.getWindowSize) {
+  if (tty.isatty(1) && tty.isatty(2)) {
+    if (process.stdout.getWindowSize) {
       width = process.stdout.getWindowSize(1)[0];
       height = process.stdout.getWindowSize(1)[1];
     } else if (tty.getWindowSize) {
@@ -25,7 +25,7 @@ module.exports = (function() {
       width = process.stdout.rows;
     }
   } else {
-    new Error('window-size could not get size with tty or process.stdout.');
+    Error('window-size could not get size with tty or process.stdout.');
   }
 
   return {height: height, width: width};

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /*!
  * window-size <https://github.com/jonschlinkert/window-size>
  *
@@ -5,7 +7,7 @@
  * Licensed under the MIT license.
  */
 
-const tty = require('tty');
+var tty = require('tty');
 
 module.exports = (function() {
   var width;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/jonschlinkert"
   },
   "scripts": {
-    "//pretest": "semistandard",
+    "pretest": "semistandard",
     "test": "tap --coverage test.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "name": "Jon Schlinkert",
     "url": "https://github.com/jonschlinkert"
   },
+  "scripts": {
+    "//pretest": "semistandard",
+    "test": "tap --coverage test.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/jonschlinkert/window-size.git"
@@ -33,5 +37,9 @@
     "tty",
     "width",
     "window"
-  ]
+  ],
+  "devDependencies": {
+    "semistandard": "^7.0.2",
+    "tap": "^2.2.1"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,8 @@
+var tap = require('tap');
+
+tap.test('returns object with width and height', function (t) {
+  var wsize = require('./');
+  t.ok(~Object.keys(wsize).indexOf('width'));
+  t.ok(~Object.keys(wsize).indexOf('height'));
+  t.done();
+});


### PR DESCRIPTION
I have a library that executes node with strict-mode enabled, I was unable to upgrade to `yargs` in this codebase because I ran into an issue involving strict mode:

<img width="495" alt="screen shot 2015-11-15 at 12 20 16 pm" src="https://cloud.githubusercontent.com/assets/194609/11170235/0f9305e4-8b83-11e5-91d7-2538e986af78.png">

Unfortunately, prior to iojs `const foo = require('bar');` does not work in strict mode. In this pull I've:

1. added a test that fails on older versions of Node.js if `var` is switched to `const`.
2. added `semistandard` which closely matches your coding style.
3. I've added a .travis.yml, it would be awesome if you could enable CI for this repo :+1: 

Thanks for the great module, helps make yargs' CLI layout feel like magic.