### PR TITLE
Windows/cygwin/appveyor test support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+# Test against this version of Node.js
+environment:
+  matrix:
+    # node.js
+    - nodejs_version: "8.0"
+    - nodejs_version: "7.0"
+    - nodejs_version: "6.0"
+    - nodejs_version: "5.0"
+    - nodejs_version: "4.0"
+    - nodejs_version: "0.12"
+    - nodejs_version: "0.10"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/index.js
+++ b/index.js
@@ -7,131 +7,29 @@
 
 'use strict';
 
-var os = require('os');
-var isNumber = require('is-number');
 var define = require('define-property');
-var cp = require('child_process');
-
-function windowSize(options) {
-  options = options || {};
-  return streamSize(options, 'stdout') ||
-    streamSize(options, 'stderr') ||
-    envSize() ||
-    ttySize(options);
-}
-
-function streamSize(options, name) {
-  var stream = (process && process[name]) || options[name];
-  var size;
-
-  if (!stream) return;
-  if (typeof stream.getWindowSize === 'function') {
-    size = stream.getWindowSize();
-    if (isSize(size)) {
-      return {
-        width: size[0],
-        height: size[1],
-        type: name
-      };
-    }
-  }
-
-  size = [stream.columns, stream.rows];
-  if (isSize(size)) {
-    return {
-      width: Number(size[0]),
-      height: Number(size[1]),
-      type: name
-    };
-  }
-}
-
-function envSize() {
-  if (process && process.env) {
-    var size = [process.env.COLUMNS, process.env.ROWS];
-    if (isSize(size)) {
-      return {
-        width: Number(size[0]),
-        height: Number(size[1]),
-        type: 'process.env'
-      };
-    }
-  }
-}
-
-function ttySize(options, stdout) {
-  var tty = options.tty || require('tty');
-  if (tty && typeof tty.getWindowSize === 'function') {
-    var size = tty.getWindowSize(stdout);
-    if (isSize(size)) {
-      return {
-        width: Number(size[1]),
-        height: Number(size[0]),
-        type: 'tty'
-      };
-    }
-  }
-}
-
-function winSize() {
-  if (os.release().startsWith('10')) {
-    var cmd = 'wmic path Win32_VideoController get CurrentHorizontalResolution,CurrentVerticalResolution';
-    var numberPattern = /\d+/g;
-    var code = cp.execSync(cmd).toString();
-    var size = code.match(numberPattern);
-    if (isSize(size)) {
-      return {
-        width: Number(size[0]),
-        height: Number(size[1]),
-        type: 'windows'
-      };
-    }
-  }
-}
-
-function tputSize() {
-  try {
-    var buf = cp.execSync('tput cols && tput lines');
-    var size = buf.toString().trim().split('\n');
-    if (isSize(size)) {
-      return {
-        width: Number(size[0]),
-        height: Number(size[1]),
-        type: 'tput'
-      };
-    }
-  } catch (err) {}
-}
-
-/**
- * Returns true if the given size array has
- * valid height and width values.
- */
-
-function isSize(size) {
-  return Array.isArray(size) && isNumber(size[0]) && isNumber(size[1]);
-}
+var utils = require('./utils');
 
 /**
  * Expose `windowSize`
  */
 
-module.exports = windowSize();
+module.exports = utils.get();
 
 if (module.exports) {
   /**
    * Expose `windowSize.get` method
    */
 
-  define(module.exports, 'get', windowSize);
+  define(module.exports, 'get', utils.get);
 
   /**
    * Expose methods for unit tests
    */
 
-  define(module.exports, 'env', envSize);
-  define(module.exports, 'tty', ttySize);
-  define(module.exports, 'tput', tputSize);
-  define(module.exports, 'win', winSize);
+  define(module.exports, 'env', utils.env);
+  define(module.exports, 'tty', utils.tty);
+  define(module.exports, 'tput', utils.tput);
+  define(module.exports, 'win', utils.win);
 }
 

--- a/index.js
+++ b/index.js
@@ -118,17 +118,20 @@ function isSize(size) {
 
 module.exports = windowSize();
 
-/**
- * Expose `windowSize.get` method
- */
+if (module.exports) {
+  /**
+   * Expose `windowSize.get` method
+   */
 
-define(module.exports, 'get', windowSize);
+  define(module.exports, 'get', windowSize);
 
-/**
- * Expose methods for unit tests
- */
+  /**
+   * Expose methods for unit tests
+   */
 
-define(module.exports, 'env', envSize);
-define(module.exports, 'tty', ttySize);
-define(module.exports, 'tput', tputSize);
-define(module.exports, 'win', winSize);
+  define(module.exports, 'env', envSize);
+  define(module.exports, 'tty', ttySize);
+  define(module.exports, 'tput', tputSize);
+  define(module.exports, 'win', winSize);
+}
+

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "contributors": [
     "Benjamin E. Coe (https://twitter.com/benjamincoe)",
+    "Brian Woodward (https://twitter.com/doowb)",
     "Carlos Hernández Gómez (http://www.twitter.com/k4rliky)",
     "Jannis Redmann (http://jannisr.de)",
     "Jon Schlinkert (http://twitter.com/jonschlinkert)",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "license": "MIT",
   "files": [
     "cli.js",
-    "index.js"
+    "index.js",
+    "utils.js"
   ],
   "main": "index.js",
   "bin": "cli.js",

--- a/test.js
+++ b/test.js
@@ -1,43 +1,68 @@
 'use strict';
 
 require('mocha');
-var isCI = process.env.TRAVIS || process.env.CI;
+var isCI = process.env.TRAVIS || process.env.APPVEYOR || process.env.CI;
 var assert = require('assert');
+var utils = require('./utils');
 var size = require('./');
 var tty = require('tty');
 
+function override(obj) {
+  var getWindowSize = obj.getWindowSize;
+  var columns = obj.columns;
+  var rows = obj.rows;
+
+  obj.getWindowSize = null;
+  obj.columns = null;
+  obj.rows = null;
+
+  return function() {
+    obj.getWindowSize = getWindowSize;
+    obj.columns = columns;
+    obj.rows = rows;
+  };
+}
+
 describe('window-size', function() {
   it('should return an object with width and height', function() {
-    assert.equal(typeof size.width, 'number');
-    assert.equal(typeof size.height, 'number');
+    if (!process.env.APPVEYOR) {
+      assert.equal(typeof size.width, 'number');
+      assert.equal(typeof size.height, 'number');
+    }
   });
 
   it('should expose a `.get` method to get up-to-date size', function() {
     var s = size.get();
-    assert.equal(typeof s.width, 'number');
-    assert.equal(typeof s.height, 'number');
+    if (!process.env.APPVEYOR) {
+      assert.equal(typeof s.width, 'number');
+      assert.equal(typeof s.height, 'number');
+    }
   });
 
   it('should get size from process.stdout', function() {
     var count = 0;
+    var restore = override(process.stdout);
     process.stdout.getWindowSize = function() {
       count++;
     };
 
     size.get();
+    restore();
     assert.equal(count, 1);
   });
 
   it('should get size from process.stderr', function() {
+    var restoreOut = override(process.stdout);
+    var restoreErr = override(process.stderr);
+
     var count = 0;
-    process.stdout.getWindowSize = null;
-    process.stdout.columns = null;
-    process.stdout.rows = null;
     process.stderr.getWindowSize = function() {
       count++;
     };
 
     size.get();
+    restoreOut();
+    restoreErr();
     assert.equal(count, 1);
   });
 
@@ -55,20 +80,19 @@ describe('window-size', function() {
   });
 
   it('should get size from tty', function() {
+    var restoreOut = override(process.stdout);
+    var restoreErr = override(process.stderr);
+    var restoreTty = override(tty);
+
     var count = 0;
-
-    process.stdout.getWindowSize = null;
-    process.stdout.columns = null;
-    process.stdout.rows = null;
-    process.stderr.getWindowSize = null;
-    process.stderr.columns = null;
-    process.stderr.rows = null;
-
     tty.getWindowSize = function() {
       count++;
     };
 
     size.get();
+    restoreOut();
+    restoreErr();
+    restoreTty();
     assert.equal(count, 1);
   });
 
@@ -79,6 +103,49 @@ describe('window-size', function() {
       assert.equal(typeof s.width, 'number');
       assert.equal(typeof s.height, 'number');
     }
+  });
+
+  describe('utils', function() {
+    it('should expose a `.get` method to get up-to-date size', function() {
+      var s = utils.get();
+      assert.equal(typeof s.width, 'number');
+      assert.equal(typeof s.height, 'number');
+    });
+
+    it('should get size from process.env', function() {
+      process.env.COLUMNS = 80;
+      process.env.ROWS = 25;
+
+      var s = utils.env();
+      assert(s);
+      assert.equal(s.width, 80);
+      assert.equal(s.height, 25);
+
+      process.env.COLUMNS = null;
+      process.env.ROWS = null;
+    });
+
+    it('should get size from tty', function() {
+      var restoreTty = override(tty);
+
+      var count = 0;
+      tty.getWindowSize = function() {
+        count++;
+      };
+
+      utils.tty({});
+      restoreTty();
+      assert.equal(count, 1);
+    });
+
+    it('should get size from tput', function() {
+      if (!isCI) {
+        var s = utils.tput();
+        assert(s);
+        assert.equal(typeof s.width, 'number');
+        assert.equal(typeof s.height, 'number');
+      }
+    });
   });
 });
 

--- a/test.js
+++ b/test.js
@@ -116,8 +116,12 @@ describe('window-size', function() {
   describe('utils', function() {
     it('should expose a `.get` method to get up-to-date size', function() {
       var s = utils.get();
-      assert.equal(typeof s.width, 'number');
-      assert.equal(typeof s.height, 'number');
+      if (process.env.APPVEYOR) {
+        assert.equal(typeof s, 'undefined');
+      } else {
+        assert.equal(typeof s.width, 'number');
+        assert.equal(typeof s.height, 'number');
+      }
     });
 
     it('should get size from process.env', function() {

--- a/test.js
+++ b/test.js
@@ -32,68 +32,76 @@ describe('window-size', function() {
   });
 
   it('should expose a `.get` method to get up-to-date size', function() {
-    var s = size.get();
     if (!process.env.APPVEYOR) {
+      var s = size.get();
       assert.equal(typeof s.width, 'number');
       assert.equal(typeof s.height, 'number');
     }
   });
 
   it('should get size from process.stdout', function() {
-    var count = 0;
-    var restore = override(process.stdout);
-    process.stdout.getWindowSize = function() {
-      count++;
-    };
+    if (!process.env.APPVEYOR) {
+      var count = 0;
+      var restore = override(process.stdout);
+      process.stdout.getWindowSize = function() {
+        count++;
+      };
 
-    size.get();
-    restore();
-    assert.equal(count, 1);
+      size.get();
+      restore();
+      assert.equal(count, 1);
+    }
   });
 
   it('should get size from process.stderr', function() {
-    var restoreOut = override(process.stdout);
-    var restoreErr = override(process.stderr);
+    if (!process.env.APPVEYOR) {
+      var restoreOut = override(process.stdout);
+      var restoreErr = override(process.stderr);
 
-    var count = 0;
-    process.stderr.getWindowSize = function() {
-      count++;
-    };
+      var count = 0;
+      process.stderr.getWindowSize = function() {
+        count++;
+      };
 
-    size.get();
-    restoreOut();
-    restoreErr();
-    assert.equal(count, 1);
+      size.get();
+      restoreOut();
+      restoreErr();
+      assert.equal(count, 1);
+    }
   });
 
   it('should get size from process.env', function() {
-    process.env.COLUMNS = 80;
-    process.env.ROWS = 25;
+    if (!process.env.APPVEYOR) {
+      process.env.COLUMNS = 80;
+      process.env.ROWS = 25;
 
-    var s = size.env();
-    assert(s);
-    assert.equal(s.width, 80);
-    assert.equal(s.height, 25);
+      var s = size.env();
+      assert(s);
+      assert.equal(s.width, 80);
+      assert.equal(s.height, 25);
 
-    process.env.COLUMNS = null;
-    process.env.ROWS = null;
+      process.env.COLUMNS = null;
+      process.env.ROWS = null;
+    }
   });
 
   it('should get size from tty', function() {
-    var restoreOut = override(process.stdout);
-    var restoreErr = override(process.stderr);
-    var restoreTty = override(tty);
+    if (!process.env.APPVEYOR) {
+      var restoreOut = override(process.stdout);
+      var restoreErr = override(process.stderr);
+      var restoreTty = override(tty);
 
-    var count = 0;
-    tty.getWindowSize = function() {
-      count++;
-    };
+      var count = 0;
+      tty.getWindowSize = function() {
+        count++;
+      };
 
-    size.get();
-    restoreOut();
-    restoreErr();
-    restoreTty();
-    assert.equal(count, 1);
+      size.get();
+      restoreOut();
+      restoreErr();
+      restoreTty();
+      assert.equal(count, 1);
+    }
   });
 
   it('should get size from tput', function() {

--- a/utils.js
+++ b/utils.js
@@ -9,7 +9,6 @@
 
 var os = require('os');
 var isNumber = require('is-number');
-var define = require('define-property');
 var cp = require('child_process');
 
 function windowSize(options) {

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,125 @@
+/*!
+ * window-size <https://github.com/jonschlinkert/window-size>
+ *
+ * Copyright (c) 2014-2017, Jon Schlinkert.
+ * Released under the MIT License.
+ */
+
+'use strict';
+
+var os = require('os');
+var isNumber = require('is-number');
+var define = require('define-property');
+var cp = require('child_process');
+
+function windowSize(options) {
+  options = options || {};
+  return streamSize(options, 'stdout') ||
+    streamSize(options, 'stderr') ||
+    envSize() ||
+    ttySize(options);
+}
+
+function streamSize(options, name) {
+  var stream = (process && process[name]) || options[name];
+  var size;
+
+  if (!stream) return;
+  if (typeof stream.getWindowSize === 'function') {
+    size = stream.getWindowSize();
+    if (isSize(size)) {
+      return {
+        width: size[0],
+        height: size[1],
+        type: name
+      };
+    }
+  }
+
+  size = [stream.columns, stream.rows];
+  if (isSize(size)) {
+    return {
+      width: Number(size[0]),
+      height: Number(size[1]),
+      type: name
+    };
+  }
+}
+
+function envSize() {
+  if (process && process.env) {
+    var size = [process.env.COLUMNS, process.env.ROWS];
+    if (isSize(size)) {
+      return {
+        width: Number(size[0]),
+        height: Number(size[1]),
+        type: 'process.env'
+      };
+    }
+  }
+}
+
+function ttySize(options, stdout) {
+  var tty = options.tty || require('tty');
+  if (tty && typeof tty.getWindowSize === 'function') {
+    var size = tty.getWindowSize(stdout);
+    if (isSize(size)) {
+      return {
+        width: Number(size[1]),
+        height: Number(size[0]),
+        type: 'tty'
+      };
+    }
+  }
+}
+
+function winSize() {
+  if (os.release().startsWith('10')) {
+    var cmd = 'wmic path Win32_VideoController get CurrentHorizontalResolution,CurrentVerticalResolution';
+    var numberPattern = /\d+/g;
+    var code = cp.execSync(cmd).toString();
+    var size = code.match(numberPattern);
+    if (isSize(size)) {
+      return {
+        width: Number(size[0]),
+        height: Number(size[1]),
+        type: 'windows'
+      };
+    }
+  }
+}
+
+function tputSize() {
+  try {
+    var buf = cp.execSync('tput cols && tput lines');
+    var size = buf.toString().trim().split('\n');
+    if (isSize(size)) {
+      return {
+        width: Number(size[0]),
+        height: Number(size[1]),
+        type: 'tput'
+      };
+    }
+  } catch (err) {}
+}
+
+/**
+ * Returns true if the given size array has
+ * valid height and width values.
+ */
+
+function isSize(size) {
+  return Array.isArray(size) && isNumber(size[0]) && isNumber(size[1]);
+}
+
+/**
+ * Expose `windowSize`
+ */
+
+module.exports = {
+  get: windowSize,
+  env: envSize,
+  tty: ttySize,
+  tput: tputSize,
+  win: winSize
+};


### PR DESCRIPTION
This PR moves the methods into a `utils.js` file that can be required in separately by doing `require('window-size/utils')`. This will allow using `window-size` in environments that might not support the defaults (like cygwin mentioned in #12).

Since the default is to return `undefined` in those environments, we can't add methods to `module.exports`.

I've also added tests for the utils directly and for not testing some results on appveyor since that's an environment where `undefined` is returned. [Here are the appveyor results](https://ci.appveyor.com/project/doowb/window-size) from my fork.

The other option I was thinking of (to keep all the code in one file) was to always export an object but to set `.width` and `.height` to `undefined`. That would be a breaking change so it might be something to consider later.