### PR TITLE
Fix size.tput()

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -90,7 +90,7 @@ function winSize() {
 
 function tputSize() {
   try {
-    var buf = cp.execSync('tput cols && tput lines');
+    var buf = cp.execSync('tput cols && tput lines', {stdio: ['ignore', 'pipe', process.stderr]});
     var size = buf.toString().trim().split('\n');
     if (isSize(size)) {
       return {


### PR DESCRIPTION
On all platforms that I was able to test (macOS, Windows, Cygwin, Windows Subsystem for Linux), `tput.size()` was returning 80x24 all the time. The fix is to pass any one of the current process stdio streams to the `cp.execSync()` call that runs tput, while leaving stdout set to `'pipe'`.

tput is also the only working way to get the window size on Cygwin (at least in most consoles), so it might be a good idea to call `.tputSize()` in the main function so this module behaves properly on those platforms.