### PR TITLE
fix: replace is-number dependency with a one liner

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "define-property": "^1.0.0",
-    "is-number": "^3.0.0"
+    "define-property": "^1.0.0"
   },
   "devDependencies": {
     "gulp-format-md": "^0.1.12",

--- a/utils.js
+++ b/utils.js
@@ -8,7 +8,7 @@
 'use strict';
 
 var os = require('os');
-var isNumber = require('is-number');
+var isNumber = (n) => (typeof n === "number" && n - n === 0) || (typeof n === "string" && Number.isFinite(+n) && n.trim() !== "");
 var cp = require('child_process');
 
 function windowSize(options) {


### PR DESCRIPTION
This PR removes is-number package with a one line with identical code.